### PR TITLE
[ISSUE4] 응답모델에 세부 에러 메세지 내용 추가 및 공통 로직 및 Enum 추가

### DIFF
--- a/src/main/java/com/covelopfit/autotrading/common/ResponseCode.java
+++ b/src/main/java/com/covelopfit/autotrading/common/ResponseCode.java
@@ -1,0 +1,20 @@
+package com.covelopfit.autotrading.common;
+
+import lombok.Getter;
+
+@Getter
+public enum ResponseCode {
+
+    SUCCESS(200, "Success"),
+    ACCEPTED(202, "Accepted"),
+    INTERNAL_SERVER_ERROR(500,"Internal Server Error"),
+    BAD_REQUEST(400,"Bad Request");
+
+    private final String message;
+    private final int status;
+
+    ResponseCode(final int status, final String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/covelopfit/autotrading/controller/OrderController.java
+++ b/src/main/java/com/covelopfit/autotrading/controller/OrderController.java
@@ -36,9 +36,13 @@ public class OrderController {
 
         if(orderApiResponse == null){
             log.error("[OrderAPI] parameter validation fail");
-            return new ResponseEntity(orderApiResponse, HttpStatus.BAD_REQUEST);
+            return getErrorResponse();
         }
-        return new ResponseEntity(orderApiResponse, HttpStatus.OK);
+        return ResponseEntity.ok().body(orderApiResponse);
 
+    }
+
+    private ResponseEntity getErrorResponse() {
+        return new ResponseEntity<>(orderService.getErrorResponseJson(), HttpStatus.valueOf(orderService.getResponseCode().getStatus()));
     }
 }

--- a/src/main/java/com/covelopfit/autotrading/controller/OrderController.java
+++ b/src/main/java/com/covelopfit/autotrading/controller/OrderController.java
@@ -35,14 +35,10 @@ public class OrderController {
         OrderApiResponse orderApiResponse = orderService.postOrder(orderForm);
 
         if(orderApiResponse == null){
-            log.error("[OrderAPI] parameter validation fail");
-            return getErrorResponse();
+            return ResponseEntity.unprocessableEntity().build();
         }
         return ResponseEntity.ok().body(orderApiResponse);
 
     }
 
-    private ResponseEntity getErrorResponse() {
-        return new ResponseEntity<>(orderService.getErrorResponseJson(), HttpStatus.valueOf(orderService.getResponseCode().getStatus()));
-    }
 }

--- a/src/main/java/com/covelopfit/autotrading/exception/CommonExceptionHandler.java
+++ b/src/main/java/com/covelopfit/autotrading/exception/CommonExceptionHandler.java
@@ -1,0 +1,56 @@
+package com.covelopfit.autotrading.exception;
+
+import com.covelopfit.autotrading.common.ResponseCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.security.NoSuchAlgorithmException;
+
+
+@ControllerAdvice
+public class CommonExceptionHandler {
+
+    protected ResponseCode responseCode;
+    protected String errorMessage;
+
+    @ResponseBody
+    @ExceptionHandler(value = {Exception.class})
+    protected ResponseEntity exceptionHandler(IllegalArgumentException e) {
+        setResponseCode(ResponseCode.INTERNAL_SERVER_ERROR);
+        setErrorMessage("특정 Excpetion, IllegalArgumentException : " + e.getMessage());
+        return getErrorResponse();
+    }
+
+
+    private ResponseEntity getErrorResponse() {
+        return new ResponseEntity<>(getErrorResponseJson(), HttpStatus.valueOf(getResponseCode().getStatus()));
+    }
+
+    public ResponseCode getResponseCode() {
+        return this.responseCode;
+    }
+
+    public String getErrorMessage() {
+        return this.errorMessage;
+    }
+
+    protected void setResponseCode(ResponseCode responseCode) {
+        this.responseCode = responseCode;
+    }
+
+    protected void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public String getErrorResponseJson() {
+        StringBuilder errorResponseJson = new StringBuilder();
+        String errorString = this.responseCode.getMessage() + " (" + this.errorMessage + ")";
+        errorResponseJson.append("{\"error\":\"");
+        errorResponseJson.append(errorString);
+        errorResponseJson.append("\"}");
+        return errorResponseJson.toString();
+    }
+}

--- a/src/main/java/com/covelopfit/autotrading/service/BaseService.java
+++ b/src/main/java/com/covelopfit/autotrading/service/BaseService.java
@@ -1,0 +1,36 @@
+package com.covelopfit.autotrading.service;
+
+import com.covelopfit.autotrading.common.ResponseCode;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BaseService {
+
+    protected ResponseCode responseCode;
+    protected String errorMessage;
+
+    public ResponseCode getResponseCode() {
+        return this.responseCode;
+    }
+
+    public String getErrorMessage() {
+        return this.errorMessage;
+    }
+
+    protected void setResponseCode(ResponseCode responseCode) {
+        this.responseCode = responseCode;
+    }
+
+    protected void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public String getErrorResponseJson() {
+        StringBuilder errorResponseJson = new StringBuilder();
+        String errorString = this.responseCode.getMessage() + " (" + this.errorMessage + ")";
+        errorResponseJson.append("{\"error\":\"");
+        errorResponseJson.append(errorString);
+        errorResponseJson.append("\"}");
+        return errorResponseJson.toString();
+    }
+}

--- a/src/main/java/com/covelopfit/autotrading/service/BaseService.java
+++ b/src/main/java/com/covelopfit/autotrading/service/BaseService.java
@@ -1,36 +1,8 @@
 package com.covelopfit.autotrading.service;
 
-import com.covelopfit.autotrading.common.ResponseCode;
 import org.springframework.stereotype.Service;
 
 @Service
 public class BaseService {
 
-    protected ResponseCode responseCode;
-    protected String errorMessage;
-
-    public ResponseCode getResponseCode() {
-        return this.responseCode;
-    }
-
-    public String getErrorMessage() {
-        return this.errorMessage;
-    }
-
-    protected void setResponseCode(ResponseCode responseCode) {
-        this.responseCode = responseCode;
-    }
-
-    protected void setErrorMessage(String errorMessage) {
-        this.errorMessage = errorMessage;
-    }
-
-    public String getErrorResponseJson() {
-        StringBuilder errorResponseJson = new StringBuilder();
-        String errorString = this.responseCode.getMessage() + " (" + this.errorMessage + ")";
-        errorResponseJson.append("{\"error\":\"");
-        errorResponseJson.append(errorString);
-        errorResponseJson.append("\"}");
-        return errorResponseJson.toString();
-    }
 }

--- a/src/main/java/com/covelopfit/autotrading/service/OrderService.java
+++ b/src/main/java/com/covelopfit/autotrading/service/OrderService.java
@@ -62,7 +62,6 @@ public class OrderService extends BaseService {
 
         try {
 
-
            MessageDigest md;
            md = MessageDigest.getInstance("SHA-512");
            md.update(queryString.getBytes("UTF-8"));
@@ -89,10 +88,7 @@ public class OrderService extends BaseService {
 
 
            result = objectMapper.readValue(entity.getContent(), OrderApiResponse.class);
-        } catch (IOException | NoSuchAlgorithmException | IllegalArgumentException e) {
-
-            setResponseCode(ResponseCode.INTERNAL_SERVER_ERROR);
-            setErrorMessage("서버에서의 에러 : " + e.getMessage());
+        } catch (IOException | NoSuchAlgorithmException e) {
             return null;
         }
 

--- a/src/main/java/com/covelopfit/autotrading/service/OrderService.java
+++ b/src/main/java/com/covelopfit/autotrading/service/OrderService.java
@@ -2,6 +2,7 @@ package com.covelopfit.autotrading.service;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.covelopfit.autotrading.common.ResponseCode;
 import com.covelopfit.autotrading.dto.OrderApiResponse;
 import com.covelopfit.autotrading.dto.OrderForm;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -12,7 +13,6 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.util.EntityUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Service;
@@ -28,7 +28,7 @@ import java.util.UUID;
 
 @Service
 @PropertySource(ignoreResourceNotFound = false, value = "classpath:application_api_key.properties")
-public class OrderService {
+public class OrderService extends BaseService {
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
@@ -89,9 +89,10 @@ public class OrderService {
 
 
            result = objectMapper.readValue(entity.getContent(), OrderApiResponse.class);
-        } catch (IOException | NoSuchAlgorithmException e) {
+        } catch (IOException | NoSuchAlgorithmException | IllegalArgumentException e) {
 
-            e.printStackTrace();
+            setResponseCode(ResponseCode.INTERNAL_SERVER_ERROR);
+            setErrorMessage("서버에서의 에러 : " + e.getMessage());
             return null;
         }
 


### PR DESCRIPTION
### 관련 이슈
- https://github.com/92-jun/CovelopFit/issues/4
- #6 
- 관련 PR  : 없음

### 변경 이유
- 코드 중복의 방지를 위해 공통 로직 중앙화
-  우리 API 자체의 세부 에러메세지 내용 노출 필요
- 
### 변경 내용
- Unchecked Error 중 공통적으로 노출될 에러로 예상되는 코드와 메세지를 @ControllerAdvice로 중앙화
### 추가 정보
없음