### PR TITLE
[Issue4] 공통 response 생성 및 적용

### DIFF
--- a/src/main/java/com/covelopfit/autotrading/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/covelopfit/autotrading/controller/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.covelopfit.autotrading.controller;
 
 
+import com.covelopfit.autotrading.dto.BaseResponse;
+import com.covelopfit.autotrading.dto.OrderApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,10 +17,21 @@ public class GlobalExceptionHandler {
 
     @ResponseBody
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(value = {IllegalArgumentException.class})
+    protected BaseResponse illegalArgumentExceptionHandler(Exception e) {
+        log.error(String.format("[error] Argument 에러 %s", e.toString()));
+        e.printStackTrace();
+        return new BaseResponse(HttpStatus.INTERNAL_SERVER_ERROR, "서비스 내 API argument 에러");
+    }
+
+
+    @ResponseBody
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(value = {Exception.class})
-    protected ResponseEntity exceptionHandler(Exception e) {
+    protected BaseResponse exceptionHandler(Exception e) {
         log.error(String.format("[error] 확인되지 않은 에러 %s", e.toString()));
-        return new ResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR);
+        e.printStackTrace();
+        return new BaseResponse(HttpStatus.INTERNAL_SERVER_ERROR, "확인되지 않은 에러 발생");
     }
 
 }

--- a/src/main/java/com/covelopfit/autotrading/controller/OrderController.java
+++ b/src/main/java/com/covelopfit/autotrading/controller/OrderController.java
@@ -1,5 +1,6 @@
 package com.covelopfit.autotrading.controller;
 
+import com.covelopfit.autotrading.dto.BaseResponse;
 import com.covelopfit.autotrading.dto.OrderApiResponse;
 import com.covelopfit.autotrading.dto.OrderForm;
 import com.covelopfit.autotrading.service.OrderService;
@@ -27,14 +28,14 @@ public class OrderController {
 
     @PostMapping(value = "order")
     @ResponseBody
-    public ResponseEntity postOrder(@ModelAttribute @Valid OrderForm orderForm) {
+    public BaseResponse postOrder(@ModelAttribute @Valid OrderForm orderForm) {
         log.debug(orderForm.toString());
         OrderApiResponse orderApiResponse = orderService.postOrder(orderForm);
 
         if(orderApiResponse == null){
-            return new ResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR);
+            return new BaseResponse(HttpStatus.INTERNAL_SERVER_ERROR, "OrderService 내 에러 or API 실패");
         }
 
-        return new ResponseEntity(orderApiResponse, HttpStatus.OK);
+        return new BaseResponse(HttpStatus.OK, "성공", orderApiResponse);
     }
 }

--- a/src/main/java/com/covelopfit/autotrading/dto/BaseResponse.java
+++ b/src/main/java/com/covelopfit/autotrading/dto/BaseResponse.java
@@ -1,0 +1,23 @@
+package com.covelopfit.autotrading.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.http.HttpStatus;
+
+@Data
+public class BaseResponse {
+    private HttpStatus code;
+    private String message;
+    private Object data;
+
+    public BaseResponse(HttpStatus code, String message, Object data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+
+    public BaseResponse(HttpStatus code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/covelopfit/autotrading/service/OrderService.java
+++ b/src/main/java/com/covelopfit/autotrading/service/OrderService.java
@@ -85,7 +85,7 @@ public class OrderService {
            request.setEntity(new StringEntity(new Gson().toJson(params)));
 
            HttpResponse response = client.execute(request);
-           if (response.getStatusLine().getStatusCode() != 200) {
+           if (response.getStatusLine().getStatusCode() != 201) {
                return null;
            }
 


### PR DESCRIPTION
### 관련 이슈
- #4 
- #6 

### 변경 이유
- 공통 response 및 적용이 필요 했음.

### 변경 내용
- 1. 공통 response 생성 
- 2. 기존 서비스 response들에 대해 적용
- 3. IllegalArgumentException 처리 핸들러를 GlobalExceptionHandler에 추가.
- 4. 테스트가 제대로 안되어서 확인해보니 업비트 API 성공 response code가 201이여서 수정함.

### 추가 정보
- 공통 response 이름 (BaseResponse) -> 변경 필요하면 언급 요망
- 공통 response에 data 변수를 처음에는 주문 API 말고도 다른 API에도 사용할 것 같아 Template으로 했는데
  상황에 따른 코드 처리가 상당히 불편하고 많았음. 그래서 결국 Object로 바꿨는데 괜찮을까?