### PR TITLE
Issue4 orders get and delete

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'com.auth0:java-jwt:3.18.2'
 	implementation 'org.apache.httpcomponents:httpclient:4.5'
 	implementation 'com.google.code.gson:gson:2.8.5'

--- a/src/main/java/com/covelopfit/autotrading/common/ResponseCode.java
+++ b/src/main/java/com/covelopfit/autotrading/common/ResponseCode.java
@@ -1,0 +1,20 @@
+package com.covelopfit.autotrading.common;
+
+import lombok.Getter;
+
+@Getter
+public enum ResponseCode {
+
+    SUCCESS(200, "Success"),
+    ACCEPTED(202, "Accepted"),
+    INTERNAL_SERVER_ERROR(500,"Internal Server Error"),
+    BAD_REQUEST(400,"Bad Request");
+
+    private final String message;
+    private final int status;
+
+    ResponseCode(final int status, final String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/covelopfit/autotrading/controller/OrderController.java
+++ b/src/main/java/com/covelopfit/autotrading/controller/OrderController.java
@@ -36,9 +36,13 @@ public class OrderController {
 
         if(orderApiResponse == null){
             log.error("[OrderAPI] parameter validation fail");
-            return new ResponseEntity(orderApiResponse, HttpStatus.BAD_REQUEST);
+            return getErrorResponse();
         }
-        return new ResponseEntity(orderApiResponse, HttpStatus.OK);
+        return ResponseEntity.ok().body(orderApiResponse);
 
+    }
+
+    private ResponseEntity getErrorResponse() {
+        return new ResponseEntity<>(orderService.getErrorResponseJson(), HttpStatus.valueOf(orderService.getResponseCode().getStatus()));
     }
 }

--- a/src/main/java/com/covelopfit/autotrading/controller/OrderController.java
+++ b/src/main/java/com/covelopfit/autotrading/controller/OrderController.java
@@ -35,14 +35,10 @@ public class OrderController {
         OrderApiResponse orderApiResponse = orderService.postOrder(orderForm);
 
         if(orderApiResponse == null){
-            log.error("[OrderAPI] parameter validation fail");
-            return getErrorResponse();
+            return ResponseEntity.unprocessableEntity().build();
         }
         return ResponseEntity.ok().body(orderApiResponse);
 
     }
 
-    private ResponseEntity getErrorResponse() {
-        return new ResponseEntity<>(orderService.getErrorResponseJson(), HttpStatus.valueOf(orderService.getResponseCode().getStatus()));
-    }
 }

--- a/src/main/java/com/covelopfit/autotrading/controller/OrderController.java
+++ b/src/main/java/com/covelopfit/autotrading/controller/OrderController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -25,9 +26,9 @@ public class OrderController {
         return "order-page";
     }
 
-    @PostMapping(value = "order")
+    @PostMapping(value = "orders")
     @ResponseBody
-    public CommonResponse postOrder(@ModelAttribute @Valid OrderForm orderForm) {
+    public CommonResponse postOrder(@ModelAttribute @Validated OrderForm orderForm) {
         log.debug(orderForm.toString());
         OrderApiResponse orderApiResponse = orderService.postOrder(orderForm);
 
@@ -37,4 +38,31 @@ public class OrderController {
 
         return new CommonResponse(HttpStatus.OK, "성공", orderApiResponse);
     }
+
+
+    @GetMapping(value = "order")
+    @ResponseBody
+    public CommonResponse getOrder() {
+        OrderApiResponse orderApiResponse = orderService.getOrder();
+
+        if(orderApiResponse == null){
+            return new CommonResponse(HttpStatus.INTERNAL_SERVER_ERROR, "OrderService 내 에러 or API 실패");
+        }
+
+        return new CommonResponse(HttpStatus.OK, "성공", orderApiResponse);
+    }
+
+
+    @DeleteMapping(value = "order/{uuid}")
+    @ResponseBody
+    public CommonResponse deleteOrder(@PathVariable String uuid) {
+        OrderApiResponse orderApiResponse = orderService.deleteOrder(uuid);
+
+        if(orderApiResponse == null){
+            return new CommonResponse(HttpStatus.INTERNAL_SERVER_ERROR, "OrderService 내 에러 or API 실패");
+        }
+
+        return new CommonResponse(HttpStatus.OK, "성공", orderApiResponse);
+    }
+
 }

--- a/src/main/java/com/covelopfit/autotrading/dto/OrderForm.java
+++ b/src/main/java/com/covelopfit/autotrading/dto/OrderForm.java
@@ -27,7 +27,6 @@ public class OrderForm {
     @Pattern(regexp = "^[a-z]+$")
     private String side;
 
-
     @NotBlank
     @Positive
     @Description("Order Amount. -> 주문량")

--- a/src/main/java/com/covelopfit/autotrading/exception/CommonExceptionHandler.java
+++ b/src/main/java/com/covelopfit/autotrading/exception/CommonExceptionHandler.java
@@ -1,0 +1,56 @@
+package com.covelopfit.autotrading.exception;
+
+import com.covelopfit.autotrading.common.ResponseCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.security.NoSuchAlgorithmException;
+
+
+@ControllerAdvice
+public class CommonExceptionHandler {
+
+    protected ResponseCode responseCode;
+    protected String errorMessage;
+
+    @ResponseBody
+    @ExceptionHandler(value = {Exception.class})
+    protected ResponseEntity exceptionHandler(IllegalArgumentException e) {
+        setResponseCode(ResponseCode.INTERNAL_SERVER_ERROR);
+        setErrorMessage("특정 Excpetion, IllegalArgumentException : " + e.getMessage());
+        return getErrorResponse();
+    }
+
+
+    private ResponseEntity getErrorResponse() {
+        return new ResponseEntity<>(getErrorResponseJson(), HttpStatus.valueOf(getResponseCode().getStatus()));
+    }
+
+    public ResponseCode getResponseCode() {
+        return this.responseCode;
+    }
+
+    public String getErrorMessage() {
+        return this.errorMessage;
+    }
+
+    protected void setResponseCode(ResponseCode responseCode) {
+        this.responseCode = responseCode;
+    }
+
+    protected void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public String getErrorResponseJson() {
+        StringBuilder errorResponseJson = new StringBuilder();
+        String errorString = this.responseCode.getMessage() + " (" + this.errorMessage + ")";
+        errorResponseJson.append("{\"error\":\"");
+        errorResponseJson.append(errorString);
+        errorResponseJson.append("\"}");
+        return errorResponseJson.toString();
+    }
+}

--- a/src/main/java/com/covelopfit/autotrading/service/BaseService.java
+++ b/src/main/java/com/covelopfit/autotrading/service/BaseService.java
@@ -1,0 +1,36 @@
+package com.covelopfit.autotrading.service;
+
+import com.covelopfit.autotrading.common.ResponseCode;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BaseService {
+
+    protected ResponseCode responseCode;
+    protected String errorMessage;
+
+    public ResponseCode getResponseCode() {
+        return this.responseCode;
+    }
+
+    public String getErrorMessage() {
+        return this.errorMessage;
+    }
+
+    protected void setResponseCode(ResponseCode responseCode) {
+        this.responseCode = responseCode;
+    }
+
+    protected void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public String getErrorResponseJson() {
+        StringBuilder errorResponseJson = new StringBuilder();
+        String errorString = this.responseCode.getMessage() + " (" + this.errorMessage + ")";
+        errorResponseJson.append("{\"error\":\"");
+        errorResponseJson.append(errorString);
+        errorResponseJson.append("\"}");
+        return errorResponseJson.toString();
+    }
+}

--- a/src/main/java/com/covelopfit/autotrading/service/BaseService.java
+++ b/src/main/java/com/covelopfit/autotrading/service/BaseService.java
@@ -1,36 +1,8 @@
 package com.covelopfit.autotrading.service;
 
-import com.covelopfit.autotrading.common.ResponseCode;
 import org.springframework.stereotype.Service;
 
 @Service
 public class BaseService {
 
-    protected ResponseCode responseCode;
-    protected String errorMessage;
-
-    public ResponseCode getResponseCode() {
-        return this.responseCode;
-    }
-
-    public String getErrorMessage() {
-        return this.errorMessage;
-    }
-
-    protected void setResponseCode(ResponseCode responseCode) {
-        this.responseCode = responseCode;
-    }
-
-    protected void setErrorMessage(String errorMessage) {
-        this.errorMessage = errorMessage;
-    }
-
-    public String getErrorResponseJson() {
-        StringBuilder errorResponseJson = new StringBuilder();
-        String errorString = this.responseCode.getMessage() + " (" + this.errorMessage + ")";
-        errorResponseJson.append("{\"error\":\"");
-        errorResponseJson.append(errorString);
-        errorResponseJson.append("\"}");
-        return errorResponseJson.toString();
-    }
 }

--- a/src/main/java/com/covelopfit/autotrading/service/OrderService.java
+++ b/src/main/java/com/covelopfit/autotrading/service/OrderService.java
@@ -62,7 +62,6 @@ public class OrderService extends BaseService {
 
         try {
 
-
            MessageDigest md;
            md = MessageDigest.getInstance("SHA-512");
            md.update(queryString.getBytes("UTF-8"));
@@ -89,10 +88,7 @@ public class OrderService extends BaseService {
 
 
            result = objectMapper.readValue(entity.getContent(), OrderApiResponse.class);
-        } catch (IOException | NoSuchAlgorithmException | IllegalArgumentException e) {
-
-            setResponseCode(ResponseCode.INTERNAL_SERVER_ERROR);
-            setErrorMessage("서버에서의 에러 : " + e.getMessage());
+        } catch (IOException | NoSuchAlgorithmException e) {
             return null;
         }
 

--- a/src/main/java/com/covelopfit/autotrading/service/OrderService.java
+++ b/src/main/java/com/covelopfit/autotrading/service/OrderService.java
@@ -2,6 +2,7 @@ package com.covelopfit.autotrading.service;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.covelopfit.autotrading.common.ResponseCode;
 import com.covelopfit.autotrading.dto.OrderApiResponse;
 import com.covelopfit.autotrading.dto.OrderForm;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -12,7 +13,6 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.util.EntityUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Service;
@@ -28,7 +28,7 @@ import java.util.UUID;
 
 @Service
 @PropertySource(ignoreResourceNotFound = false, value = "classpath:application_api_key.properties")
-public class OrderService {
+public class OrderService extends BaseService {
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
@@ -89,9 +89,10 @@ public class OrderService {
 
 
            result = objectMapper.readValue(entity.getContent(), OrderApiResponse.class);
-        } catch (IOException | NoSuchAlgorithmException e) {
+        } catch (IOException | NoSuchAlgorithmException | IllegalArgumentException e) {
 
-            e.printStackTrace();
+            setResponseCode(ResponseCode.INTERNAL_SERVER_ERROR);
+            setErrorMessage("서버에서의 에러 : " + e.getMessage());
             return null;
         }
 

--- a/src/main/java/com/covelopfit/autotrading/service/OrderService.java
+++ b/src/main/java/com/covelopfit/autotrading/service/OrderService.java
@@ -2,18 +2,22 @@ package com.covelopfit.autotrading.service;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
-import com.covelopfit.autotrading.common.ResponseCode;
 import com.covelopfit.autotrading.dto.OrderApiResponse;
 import com.covelopfit.autotrading.dto.OrderForm;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.springframework.beans.factory.annotation.Value;
+import org.apache.http.util.EntityUtils;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Service;
 
@@ -32,14 +36,14 @@ public class OrderService extends BaseService {
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
-    @Value("${upbit.api.accessKey}")
-    private String accessKey;
+    //@Value("${upbit.api.accessKey}")
+    private String accessKey = "5kNl3DOeyx5aPDWx9lkVEl1j21q0Y0RwuyIk2B1s";
 
-    @Value("${upbit.api.secretKey}")
-    private String secretKey;
+    //@Value("${upbit.api.secretKey}")
+    private String secretKey = "C0GGTPZtxxyuaVySkd7iy1busDMygRxme3BhWJPc";
 
-    @Value("${upbit.api.serverUrl}")
-    private String serverUrl;
+    //@Value("${upbit.api.serverUrl}")
+    private String serverUrl = "https://api.upbit.com/";
 
     public OrderApiResponse postOrder(OrderForm orderForm){
 
@@ -97,4 +101,96 @@ public class OrderService extends BaseService {
 
         return result;
    }
+
+    public OrderApiResponse getOrder() {
+        OrderApiResponse orderResponse = null;
+
+        HashMap<String, String> params = new HashMap<>();
+        params.put("uuid", "5025b250-6df7-4910-bb1b-8c05e5e902b1");
+
+        ArrayList<String> queryElements = new ArrayList<>();
+        for(Map.Entry<String, String> entity : params.entrySet()) {
+            queryElements.add(entity.getKey() + "=" + entity.getValue());
+        }
+
+        String queryString = String.join("&", queryElements.toArray(new String[0]));
+
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-512");
+            md.update(queryString.getBytes("UTF-8"));
+
+            String queryHash = String.format("%0128x", new BigInteger(1, md.digest()));
+
+            Algorithm algorithm = Algorithm.HMAC256(secretKey);
+            String jwtToken = JWT.create()
+                    .withClaim("access_key", accessKey)
+                    .withClaim("nonce", UUID.randomUUID().toString())
+                    .withClaim("query_hash", queryHash)
+                    .withClaim("query_hash_alg", "SHA512")
+                    .sign(algorithm);
+
+            String authenticationToken = "Bearer " + jwtToken;
+
+            HttpClient client = HttpClientBuilder.create().build();
+            HttpGet request = new HttpGet(serverUrl + "/v1/order?" + queryString);
+            request.setHeader("Content-Type", "application/json");
+            request.addHeader("Authorization", authenticationToken);
+
+            HttpResponse response = client.execute(request);
+            HttpEntity entity = response.getEntity();
+            objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+            objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            orderResponse = objectMapper.readValue(entity.getContent(),OrderApiResponse.class);
+
+        } catch (IOException | NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
+        return orderResponse;
+    }
+
+    public OrderApiResponse deleteOrder(String uuid) {
+        OrderApiResponse orderResponse = null;
+        HashMap<String, String> params = new HashMap<>();
+        params.put("uuid", uuid);
+
+        ArrayList<String> queryElements = new ArrayList<>();
+        for(Map.Entry<String, String> entity : params.entrySet()) {
+            queryElements.add(entity.getKey() + "=" + entity.getValue());
+        }
+
+        String queryString = String.join("&", queryElements.toArray(new String[0]));
+
+
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-512");
+            md.update(queryString.getBytes("UTF-8"));
+
+            String queryHash = String.format("%0128x", new BigInteger(1, md.digest()));
+
+            Algorithm algorithm = Algorithm.HMAC256(secretKey);
+            String jwtToken = JWT.create()
+                    .withClaim("access_key", accessKey)
+                    .withClaim("nonce", UUID.randomUUID().toString())
+                    .withClaim("query_hash", queryHash)
+                    .withClaim("query_hash_alg", "SHA512")
+                    .sign(algorithm);
+
+            String authenticationToken = "Bearer " + jwtToken;
+
+            HttpClient client = HttpClientBuilder.create().build();
+            HttpDelete request = new HttpDelete(serverUrl + "/v1/order?" + queryString);
+            request.setHeader("Content-Type", "application/json");
+            request.addHeader("Authorization", authenticationToken);
+
+            HttpResponse response = client.execute(request);
+            HttpEntity entity = response.getEntity();
+            objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+            objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            orderResponse = objectMapper.readValue(entity.getContent(),OrderApiResponse.class);
+
+        } catch (IOException | NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
+        return orderResponse;
+    }
 }


### PR DESCRIPTION
### 관련 이슈
- 이슈 링크
    - https://github.com/92-jun/CovelopFit/issues/4#issuecomment-955130470
    - https://github.com/92-jun/CovelopFit/issues/6#issuecomment-974822844
- 관련 PR : 없음

### 변경 이유
- 미체결 주문 정보 조회
- 미체결 주문 취소
### 변경 내용
- 주문은 각 uuid를 가지고 있으며 uuid로 각 주문에 대한 정보 획득 및 취소 가능, uuid로 정보 요청 및 획득(get), 삭제(delete) 추가. 
### 추가 정보
 *  주문 정보의 조회, 삭제를 위해서는 uuid가 반드시 필요한데, 획득 방법은 현재 post요청시의 응답값으로만 가능하다. 따라서 Post 요청시 응답으로 돌아온 uuid를 따로 저장해둘 필요가 있고, 이에 대한 논의 제안.  -> uuid 값 획득 가능한지 재확인

 * service 내에 중복되는 로직 공통화 필요
     * [인증 가능한 요청 만들기](https://docs.upbit.com/docs) 
     * 업비트에 request 요청 로직, 단 GET,POST,DELETE에 대한 구분 필요
 * 이 PR issue4 브랜치에서 다시 분기 작업 예정 (내 로컬에서만 POST 요청시 에러 발생)  