### PR TITLE
Issue4 ticker api

### DIFF
--- a/src/main/java/com/covelopfit/autotrading/controller/TickerController.java
+++ b/src/main/java/com/covelopfit/autotrading/controller/TickerController.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import java.util.List;
+
 @Slf4j
 @Controller
 @RequiredArgsConstructor
@@ -21,13 +23,13 @@ public class TickerController {
     @ResponseBody
     public CommonResponse getTicker(String marketCodes) {
 
-        TickerApiResponse tickerApiResponse = tickerService.getTicker(marketCodes);
+        List<TickerApiResponse> tickerApiResponseList = tickerService.getTickerList(marketCodes);
 
-        if(tickerApiResponse == null){
+        if(tickerApiResponseList == null){
             return new CommonResponse(HttpStatus.INTERNAL_SERVER_ERROR, "TickerService Exception 발생");
         }
 
-        return new CommonResponse(HttpStatus.OK, "성공", tickerApiResponse);
+        return new CommonResponse(HttpStatus.OK, "성공", tickerApiResponseList);
     }
 
 }

--- a/src/main/java/com/covelopfit/autotrading/controller/TickerController.java
+++ b/src/main/java/com/covelopfit/autotrading/controller/TickerController.java
@@ -1,6 +1,7 @@
 package com.covelopfit.autotrading.controller;
 
 import com.covelopfit.autotrading.dto.CommonResponse;
+import com.covelopfit.autotrading.dto.TickerApiResponse;
 import com.covelopfit.autotrading.service.TickerService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,16 +21,13 @@ public class TickerController {
     @ResponseBody
     public CommonResponse getTicker(String marketCodes) {
 
-        CommonResponse commonResponse = tickerService.getTicker(marketCodes);
+        TickerApiResponse tickerApiResponse = tickerService.getTicker(marketCodes);
 
-        if(commonResponse == null){
+        if(tickerApiResponse == null){
             return new CommonResponse(HttpStatus.INTERNAL_SERVER_ERROR, "TickerService Exception 발생");
         }
-        else if(commonResponse.getCode() != HttpStatus.valueOf(200)){
-            return commonResponse;
-        }
 
-        return commonResponse;
+        return new CommonResponse(HttpStatus.OK, "성공", tickerApiResponse);
     }
 
 }

--- a/src/main/java/com/covelopfit/autotrading/service/TickerService.java
+++ b/src/main/java/com/covelopfit/autotrading/service/TickerService.java
@@ -11,15 +11,16 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.List;
 
 @Service
 public class TickerService {
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
-    public TickerApiResponse getTicker(String marketCodes){
+    public List<TickerApiResponse> getTickerList(String marketCodes){
 
-        TickerApiResponse tickerAPIResResult = new TickerApiResponse();
+        List<TickerApiResponse> tickerAPIResResult = null;
 
         String upbitURL = "https://api.upbit.com/v1/ticker?markets=" + marketCodes;
 
@@ -35,9 +36,7 @@ public class TickerService {
                 return null;
             }
 
-            String resbody = response.body();
-
-            tickerAPIResResult = objectMapper.readValue(resbody.substring(1,resbody.length()-1), TickerApiResponse.class);
+            tickerAPIResResult = objectMapper.readValue(response.body(), objectMapper.getTypeFactory().constructCollectionType(List.class, TickerApiResponse.class));
 
         }catch (IOException | InterruptedException e) {
             e.printStackTrace();

--- a/src/main/java/com/covelopfit/autotrading/service/TickerService.java
+++ b/src/main/java/com/covelopfit/autotrading/service/TickerService.java
@@ -17,7 +17,7 @@ public class TickerService {
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
-    public CommonResponse getTicker(String marketCodes){
+    public TickerApiResponse getTicker(String marketCodes){
 
         TickerApiResponse tickerAPIResResult = new TickerApiResponse();
 
@@ -32,7 +32,7 @@ public class TickerService {
             HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
 
             if(response.statusCode() != 200){
-                return new CommonResponse(HttpStatus.valueOf(response.statusCode()), "실패");
+                return null;
             }
 
             String resbody = response.body();
@@ -44,6 +44,6 @@ public class TickerService {
             return null;
         }
 
-        return new CommonResponse(HttpStatus.valueOf(200), "성공", tickerAPIResResult);
+        return tickerAPIResResult;
     }
 }


### PR DESCRIPTION
### 관련 이슈
- #4 
- #24 

### 변경 이유
- Service에서 CommonResponse 반환 방식 다시 수정
- List 형태의 String response 처리 부분 변경

### 변경 내용
- TickerService에서 CommonResponse를 반환 하던 것에서 다시 TickerApiResponse로 변경
- TickerService에서 List 형태의 String response를 정상적인 형태로 수정
    - 기존에는 "[{....}]" 형태의 String을 맨 앞, 맨 뒤 문자를 제거해주는 방식으로 처리했음.
    - 하지만 이는 다수의 코인 조회 결과를 위해 일부러 List 형태의 String response를 반환하던 것이었음.
    - objectMapper.readValue()를 올바르게 사용함으로써 List로 올바르게 받도록 수정함.

### 추가 정보
- 없음